### PR TITLE
Add ToList() in DocGenerator for better perfermence

### DIFF
--- a/src/WebExtends/DocGenerator/Middlewares/APIDocGeneratorMiddleware.cs
+++ b/src/WebExtends/DocGenerator/Middlewares/APIDocGeneratorMiddleware.cs
@@ -62,7 +62,11 @@ namespace Aiursoft.DocGenerator.Middlewares
             }
             context.Response.StatusCode = 200;
             var actionsMatches = new List<API>();
-            var possibleControllers = Assembly.GetEntryAssembly()?.GetTypes().Where(type => typeof(ControllerBase).IsAssignableFrom(type));
+            var possibleControllers = Assembly
+                .GetEntryAssembly()
+                .GetTypes()
+                .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+                .ToList();
             foreach (var controller in possibleControllers ?? new List<Type>())
             {
                 if (!IsController(controller))


### PR DESCRIPTION
Older:
```csharp
var possibleControllers = Assembly
                .GetEntryAssembly()
                .GetTypes()
                .Where(type => typeof(ControllerBase).IsAssignableFrom(type));
```

Newer:
```csharp
var possibleControllers = Assembly
                .GetEntryAssembly()
                .GetTypes()
                .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
                .ToList();
```