### PR TITLE
#225 Improve csv generator

### DIFF
--- a/src/Abstracts/XelNaga/Attributes/CSVProperty.cs
+++ b/src/Abstracts/XelNaga/Attributes/CSVProperty.cs
@@ -2,6 +2,7 @@
 
 namespace Aiursoft.XelNaga.Attributes
 {
+    [AttributeUsage(AttributeTargets.Property, Inherited = true)]
     public class CSVProperty : Attribute
     {
         public readonly string Name;

--- a/src/Abstracts/XelNaga/Tools/CSVGenerator.cs
+++ b/src/Abstracts/XelNaga/Tools/CSVGenerator.cs
@@ -2,34 +2,40 @@
 using Aiursoft.XelNaga.Attributes;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Aiursoft.XelNaga.Tools
 {
-    public class CSVGenerator : ITransientDependency
+    public  class CSVGenerator : ITransientDependency
     {
         public byte[] BuildFromList<T>(IEnumerable<T> items) where T : new()
         {
-            var csv = "";
+            List<string> csv = new (items.Count() + 1);
             var type = typeof(T);
+            List<string> title = new ();
+            List<PropertyInfo> properties = new ();
             foreach (var prop in type.GetProperties().Where(t => t.GetCustomAttributes(typeof(CSVProperty), true).Any()))
             {
+                properties.Add(prop);
                 var attribute = prop.GetCustomAttributes(typeof(CSVProperty), true).FirstOrDefault();
-                csv += $@"""{(attribute as CSVProperty)?.Name}"",";
+                title.Add($@"""{(attribute as CSVProperty)?.Name}""");
             }
-            csv = csv.Trim(',') + "\r\n";
+
+            csv.Add(string.Join(",", title));
             foreach (var item in items)
             {
-                string newLine = "";
-                foreach (var prop in type.GetProperties().Where(t => t.GetCustomAttributes(typeof(CSVProperty), true).Any()))
+                List<string> newLine = new (properties.Count);
+                foreach(var prop in properties)
                 {
                     var propValue = prop.GetValue(item)?.ToString() ?? "null";
                     propValue = propValue.Replace("\r", "").Replace("\n", "").Replace("\\", "");
-                    newLine += $@"""{propValue }"",";
+                    newLine.Add($@"""{propValue}""");
                 }
-                newLine = newLine.Trim(',') + "\r\n";
-                csv += newLine;
+
+                csv.Add(string.Join(",", newLine));
             }
-            return csv.ToUTF8WithDom();
+
+            return string.Join("\r\n", csv).ToUTF8WithDom();
         }
     }
 }

--- a/tests/XelNaga.Tests/Tools/CSVGenerator.Tests.cs
+++ b/tests/XelNaga.Tests/Tools/CSVGenerator.Tests.cs
@@ -1,0 +1,44 @@
+using Aiursoft.XelNaga.Tools;
+using Aiursoft.XelNaga.Attributes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+
+namespace Aiursoft.XelNaga.Tests.Tools
+{
+    [TestClass]
+    public class CSVGeneratorTests
+    {
+        private class Model
+        {
+            [CSVProperty("Id")]
+            public int Id { get; set; }
+        }
+        private class Person : Model
+        {
+            [CSVProperty("Name")]
+            public string Name { get; set; }
+        }
+
+        [TestMethod]
+        public void BuildFromListEmpty()
+        {
+            Person[] persons = Array.Empty<Person>();
+            byte[] expect = "\"Name\",\"Id\"".ToUTF8WithDom();
+            CSVGenerator generator = new();
+            CollectionAssert.AreEqual(expect, generator.BuildFromList(persons));
+        }
+
+        [TestMethod]
+        public void BuildFromList()
+        {
+            Person[] persons = new [] {
+                new Person { Id = 1, Name = "alice" },
+                new Person { Id = 2, Name = "bob" },
+            };
+            byte[] expect = "\"Name\",\"Id\"\r\n\"alice\",\"1\"\r\n\"bob\",\"2\"".ToUTF8WithDom();
+            CSVGenerator generator = new();
+            CollectionAssert.AreEqual(expect, generator.BuildFromList(persons));
+        }
+    }
+}


### PR DESCRIPTION
1. Using `string.Join` method instead of `+=` operator
2. Add restrict of `CSVProperty` attribute.
3. Add unit test code of CSVGenerator